### PR TITLE
Various memory leaks plugged (Clang static analyzer)

### DIFF
--- a/src/MKAudioOutput.m
+++ b/src/MKAudioOutput.m
@@ -255,6 +255,7 @@ static OSStatus outputCallback(void *udata, AudioUnitRenderActionFlags *flags, c
     if (outputUser == nil || [outputUser messageType] != msgType) {
         if (outputUser != nil) {
             [self removeBuffer:outputUser];
+            [outputUser release];
         }
         outputUser = [[MKAudioOutputSpeech alloc] initWithSession:session sampleRate:_mixerFrequency messageType:msgType];
         [_outputLock lock];

--- a/src/MKConnection.m
+++ b/src/MKConnection.m
@@ -985,6 +985,7 @@ out:
                         [_delegate connection:self trustFailureInCertificateChain:[self peerCertificates]];
                     });
                 }
+                CFRelease(trust);
                 return YES;
             }
         }

--- a/src/MulticastDelegate.m
+++ b/src/MulticastDelegate.m
@@ -388,35 +388,38 @@ static void MulticastDelegateListNodeRelease(MulticastDelegateListNode *node)
             // Note: The node variable is now pointing to the last node in the list.
         }
 
-        // We're now going to create an array of all the nodes.
-        // This gives us a quick and easy snapshot of the current list,
-        // which will allow delegates to be added/removed from the list while we're enumerating it,
-        // all without bothering us, and without violating any of the rules listed above.
-        //
-        // Note: We're creating an array of pointers.
-        // Each pointer points to the dynamically allocated struct.
-        // If we copied the struct, we might violate rule number two.
-        // So we also retain each node, to prevent it from disappearing while we're enumerating the list.
-
-        size_t ptrSize = sizeof(node);
-
-        delegates = malloc(ptrSize * numDelegates);
-
-        // Remember that delegates is a pointer to an array of pointers.
-        // It's going to look something like this in memory:
-        //
-        // delegates ---> |ptr1|ptr2|ptr3|...|
-        //
-        // So delegates points to ptr1.
-        // And due to pointer arithmetic, delegates+1 points to ptr2.
-
-        NSUInteger i;
-        for(i = 0; i < numDelegates; i++)
+        if(numDelegates > 0)
         {
-            memcpy(delegates + i, &node, ptrSize);
-            MulticastDelegateListNodeRetain(node);
+            // We're now going to create an array of all the nodes.
+            // This gives us a quick and easy snapshot of the current list,
+            // which will allow delegates to be added/removed from the list while we're enumerating it,
+            // all without bothering us, and without violating any of the rules listed above.
+            //
+            // Note: We're creating an array of pointers.
+            // Each pointer points to the dynamically allocated struct.
+            // If we copied the struct, we might violate rule number two.
+            // So we also retain each node, to prevent it from disappearing while we're enumerating the list.
 
-            node = node->prev;
+            size_t ptrSize = sizeof(node);
+
+            delegates = malloc(ptrSize * numDelegates);
+
+            // Remember that delegates is a pointer to an array of pointers.
+            // It's going to look something like this in memory:
+            //
+            // delegates ---> |ptr1|ptr2|ptr3|...|
+            //
+            // So delegates points to ptr1.
+            // And due to pointer arithmetic, delegates+1 points to ptr2.
+
+            NSUInteger i;
+            for(i = 0; i < numDelegates; i++)
+            {
+                memcpy(delegates + i, &node, ptrSize);
+                MulticastDelegateListNodeRetain(node);
+
+                node = node->prev;
+            }
         }
     }
     return self;


### PR DESCRIPTION
The fixes are all untested, but have been fixed according to program
logic.

In the case of MulticastDelegate.m, a malloc(0) was fixed.
