### PR TITLE
Fix for #7 that gets Mac targets building properly

### DIFF
--- a/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
+++ b/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 		280D5F85132AE73C00540C3D /* libCELT-0.7.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libCELT-0.7.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		280D5F88132AE73C00540C3D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		28190CFB150D600400E07613 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
-		28656110132AE7A80011637C /* CELT-0.7.0 */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = file; path = "CELT-0.7.0"; sourceTree = BUILT_PRODUCTS_DIR; };
+		28656110132AE7A80011637C /* CELT-0.7.0.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "CELT-0.7.0.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
 		28656116132AE7A80011637C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		28656121132AE8240011637C /* CELT-0.7.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CELT-0.7.pch"; sourceTree = "<group>"; };
 		28656124132AE83B0011637C /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
@@ -115,7 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				280D5F85132AE73C00540C3D /* libCELT-0.7.0.a */,
-				28656110132AE7A80011637C /* CELT-0.7.0 */,
+				28656110132AE7A80011637C /* CELT-0.7.0.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -243,7 +243,7 @@
 			);
 			name = "CELT-0.7 (Mac)";
 			productName = "CELT-0.7.0";
-			productReference = 28656110132AE7A80011637C /* CELT-0.7.0 */;
+			productReference = 28656110132AE7A80011637C /* CELT-0.7.0.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -370,18 +370,24 @@
 		28498F27138AB6D5000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = BetaDist;
 		};
 		2865611B132AE7A80011637C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		2865611C132AE7A80011637C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -401,6 +407,8 @@
 		28A2AED01478AA2400F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = AppStore;
 		};

--- a/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
+++ b/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
@@ -1897,7 +1897,7 @@
 		2852D73B132AF4E70078051B /* xcbc_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = xcbc_enc.c; path = ../openssl/crypto/des/xcbc_enc.c; sourceTree = "<group>"; };
 		28F58C46132AF1070053C348 /* libOpenSSL.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOpenSSL.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		28F58C49132AF1070053C348 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		28F58C57132AF1170053C348 /* OpenSSL */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.dylib"; path = OpenSSL; sourceTree = BUILT_PRODUCTS_DIR; };
+		28F58C57132AF1170053C348 /* OpenSSL.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = OpenSSL.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		28F58C5D132AF1170053C348 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		28F58C66132AF1690053C348 /* OpenSSL.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenSSL.pch; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -3000,7 +3000,7 @@
 			isa = PBXGroup;
 			children = (
 				28F58C46132AF1070053C348 /* libOpenSSL.a */,
-				28F58C57132AF1170053C348 /* OpenSSL */,
+				28F58C57132AF1170053C348 /* OpenSSL.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3103,7 +3103,7 @@
 			);
 			name = "OpenSSL (Mac)";
 			productName = "OpenSSL (Mac)";
-			productReference = 28F58C57132AF1170053C348 /* OpenSSL */;
+			productReference = 28F58C57132AF1170053C348 /* OpenSSL.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -4418,6 +4418,8 @@
 		28498F1F138AB6C0000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = BetaDist;
 		};
@@ -4437,6 +4439,8 @@
 		28A2AEC81478AA0F00F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = AppStore;
 		};
@@ -4469,12 +4473,16 @@
 		28F58C62132AF1170053C348 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		28F58C63132AF1170053C348 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
+++ b/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
@@ -262,7 +262,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		2815CCC414E6DF9700AAE69C /* Opus */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.dylib"; path = Opus; sourceTree = BUILT_PRODUCTS_DIR; };
+		2815CCC414E6DF9700AAE69C /* Opus.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = Opus.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		28190D02150D611E00E07613 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		2867AAD014E6D6ED00E24B98 /* bands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bands.c; path = ../opus/celt/bands.c; sourceTree = "<group>"; };
 		2867AAD114E6D6ED00E24B98 /* celt_lpc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = celt_lpc.c; path = ../opus/celt/celt_lpc.c; sourceTree = "<group>"; };
@@ -589,7 +589,7 @@
 			isa = PBXGroup;
 			children = (
 				287D85A614E6D474002B5D79 /* libOpus.a */,
-				2815CCC414E6DF9700AAE69C /* Opus */,
+				2815CCC414E6DF9700AAE69C /* Opus.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -647,7 +647,7 @@
 			);
 			name = "Opus (Mac)";
 			productName = Opus;
-			productReference = 2815CCC414E6DF9700AAE69C /* Opus */;
+			productReference = 2815CCC414E6DF9700AAE69C /* Opus.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 		287D85A514E6D474002B5D79 /* Opus (iOS) */ = {
@@ -966,12 +966,16 @@
 		2815CCD314E6DF9700AAE69C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		2815CCD414E6DF9700AAE69C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -991,6 +995,8 @@
 		285B423B14E6E0F00045E282 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = AppStore;
 		};
@@ -1010,6 +1016,8 @@
 		285B423F14E6E0F50045E282 /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = BetaDist;
 		};

--- a/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
+++ b/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
@@ -57,7 +57,7 @@
 		28190CF2150D5D7300E07613 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		2845A6A7132D99550034D631 /* libProtocolBuffers.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libProtocolBuffers.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		2845A6AA132D99550034D631 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		2845A6B8132D99600034D631 /* ProtocolBuffers */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.dylib"; path = ProtocolBuffers; sourceTree = BUILT_PRODUCTS_DIR; };
+		2845A6B8132D99600034D631 /* ProtocolBuffers.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = ProtocolBuffers.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		2845A6BE132D99600034D631 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		2845A6C7132D9A240034D631 /* AbstractMessage_Builder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AbstractMessage_Builder.m; path = ../protobuf/src/runtime/Classes/AbstractMessage_Builder.m; sourceTree = SOURCE_ROOT; };
 		2845A6C8132D9A240034D631 /* AbstractMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AbstractMessage.m; path = ../protobuf/src/runtime/Classes/AbstractMessage.m; sourceTree = SOURCE_ROOT; };
@@ -124,7 +124,7 @@
 			isa = PBXGroup;
 			children = (
 				2845A6A7132D99550034D631 /* libProtocolBuffers.a */,
-				2845A6B8132D99600034D631 /* ProtocolBuffers */,
+				2845A6B8132D99600034D631 /* ProtocolBuffers.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -241,7 +241,7 @@
 			);
 			name = "ProtocolBuffers (Mac)";
 			productName = "ProtocolBuffers (Mac)";
-			productReference = 2845A6B8132D99600034D631 /* ProtocolBuffers */;
+			productReference = 2845A6B8132D99600034D631 /* ProtocolBuffers.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -359,12 +359,16 @@
 		2845A6C3132D99600034D631 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		2845A6C4132D99600034D631 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -384,6 +388,8 @@
 		28498F23138AB6C9000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = BetaDist;
 		};
@@ -403,6 +409,8 @@
 		28A2AECC1478AA1B00F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = AppStore;
 		};

--- a/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
+++ b/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
@@ -91,7 +91,7 @@
 		287F0263132AEFEF003C03FE /* high_lsp_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = high_lsp_tables.c; path = ../speex/libspeex/high_lsp_tables.c; sourceTree = "<group>"; };
 		28D1DAE8132AEB1400456ED6 /* libSpeex.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpeex.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		28D1DAEB132AEB1500456ED6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		28D1DAF9132AEB2200456ED6 /* Speex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.dylib"; path = Speex; sourceTree = BUILT_PRODUCTS_DIR; };
+		28D1DAF9132AEB2200456ED6 /* Speex.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = Speex.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		28D1DAFF132AEB2200456ED6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		28D1DB08132AEBB500456ED6 /* Speex.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Speex.pch; sourceTree = SOURCE_ROOT; };
 		28D1DB0C132AEBD300456ED6 /* bits.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bits.c; path = ../speex/libspeex/bits.c; sourceTree = SOURCE_ROOT; };
@@ -168,7 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				28D1DAE8132AEB1400456ED6 /* libSpeex.a */,
-				28D1DAF9132AEB2200456ED6 /* Speex */,
+				28D1DAF9132AEB2200456ED6 /* Speex.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -303,7 +303,7 @@
 			);
 			name = "Speex (Mac)";
 			productName = "Speex (Mac)";
-			productReference = 28D1DAF9132AEB2200456ED6 /* Speex */;
+			productReference = 28D1DAF9132AEB2200456ED6 /* Speex.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -434,6 +434,8 @@
 		28498F2B138AB6DB000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = BetaDist;
 		};
@@ -453,6 +455,8 @@
 		28A2AED41478AA3200F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = AppStore;
 		};
@@ -485,12 +489,16 @@
 		28D1DB04132AEB2200456ED6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		28D1DB05132AEB2200456ED6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
+++ b/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		28190D0B150D624800E07613 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		28877EBE132D96F300793CC5 /* libSpeexDSP.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpeexDSP.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		28877EC1132D96F300793CC5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		28877ECF132D975D00793CC5 /* SpeexDSP */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.dylib"; path = SpeexDSP; sourceTree = BUILT_PRODUCTS_DIR; };
+		28877ECF132D975D00793CC5 /* SpeexDSP.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = SpeexDSP.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		28877ED5132D975D00793CC5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -80,7 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				28877EBE132D96F300793CC5 /* libSpeexDSP.a */,
-				28877ECF132D975D00793CC5 /* SpeexDSP */,
+				28877ECF132D975D00793CC5 /* SpeexDSP.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -191,7 +191,7 @@
 			);
 			name = "SpeexDSP (Mac)";
 			productName = "SpeexDSP (Mac)";
-			productReference = 28877ECF132D975D00793CC5 /* SpeexDSP */;
+			productReference = 28877ECF132D975D00793CC5 /* SpeexDSP.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -268,6 +268,8 @@
 		28498F2F138AB6E2000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = BetaDist;
 		};
@@ -300,12 +302,16 @@
 		28877EDA132D975D00793CC5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		28877EDB132D975D00793CC5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -325,6 +331,8 @@
 		28A2AED81478AA3C00F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = AppStore;
 		};

--- a/MumbleKit.xcodeproj/project.pbxproj
+++ b/MumbleKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0245A131154F593200476144 /* Opus.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 285B426314E6E1200045E282 /* Opus.dylib */; };
 		2808DD9413E4D8C0008448EA /* MKPacketDataStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2845A7D1132D9C520034D631 /* MKPacketDataStream.h */; };
 		2810DED514EA81D7004482F4 /* libCELT-0.7.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 28492310132ED60700B4EAAC /* libCELT-0.7.0.a */; };
 		281EADA51530EA30000793AB /* MKDistinguishedNameParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 281EADA31530EA30000793AB /* MKDistinguishedNameParser.h */; };
@@ -124,6 +125,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0245A132154F593C00476144 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 285B425814E6E1200045E282 /* Opus.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 2815CCC314E6DF9700AAE69C;
+			remoteInfo = "Opus (Mac)";
+		};
 		283363C913EE070400A04F04 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 28492307132ED60700B4EAAC /* CELT-0.7.xcodeproj */;
@@ -316,7 +324,7 @@
 		282F6B0713624187008F555B /* MKServerPinger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MKServerPinger.m; path = src/MKServerPinger.m; sourceTree = SOURCE_ROOT; };
 		283363DC13EF535B00A04F04 /* MKChannelPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MKChannelPrivate.h; path = src/MKChannelPrivate.h; sourceTree = SOURCE_ROOT; };
 		283363DE13EF536C00A04F04 /* MKUserPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MKUserPrivate.h; path = src/MKUserPrivate.h; sourceTree = SOURCE_ROOT; };
-		2845A71A132D9B2F0034D631 /* MumbleKit */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = MumbleKit; sourceTree = BUILT_PRODUCTS_DIR; };
+		2845A71A132D9B2F0034D631 /* MumbleKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MumbleKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2845A781132D9C220034D631 /* CryptState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CryptState.cpp; path = src/CryptState.cpp; sourceTree = SOURCE_ROOT; };
 		2845A782132D9C220034D631 /* MKAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MKAudio.m; path = src/MKAudio.m; sourceTree = SOURCE_ROOT; };
 		2845A783132D9C220034D631 /* MKAudioInput.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MKAudioInput.m; path = src/MKAudioInput.m; sourceTree = SOURCE_ROOT; };
@@ -389,6 +397,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0245A131154F593200476144 /* Opus.dylib in Frameworks */,
 				28CC36F7132ED8C300241269 /* CoreAudio.framework in Frameworks */,
 				28CC36F5132ED8BA00241269 /* AudioUnit.framework in Frameworks */,
 				28CC36F3132ED8B300241269 /* AudioToolbox.framework in Frameworks */,
@@ -601,7 +610,7 @@
 			isa = PBXGroup;
 			children = (
 				28BCF2C1132AE3B40003AEC1 /* libMumbleKit.a */,
-				2845A71A132D9B2F0034D631 /* MumbleKit */,
+				2845A71A132D9B2F0034D631 /* MumbleKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -717,6 +726,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0245A133154F593C00476144 /* PBXTargetDependency */,
 				28492355132ED66F00B4EAAC /* PBXTargetDependency */,
 				28492357132ED66F00B4EAAC /* PBXTargetDependency */,
 				28492359132ED66F00B4EAAC /* PBXTargetDependency */,
@@ -725,7 +735,7 @@
 			);
 			name = "MumbleKit (Mac)";
 			productName = MumbleKit;
-			productReference = 2845A71A132D9B2F0034D631 /* MumbleKit */;
+			productReference = 2845A71A132D9B2F0034D631 /* MumbleKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		28BCF2C0132AE3B40003AEC1 /* MumbleKit (iOS) */ = {
@@ -813,8 +823,8 @@
 		};
 		28492312132ED60700B4EAAC /* CELT-0.7.0 */ = {
 			isa = PBXReferenceProxy;
-			fileType = file;
-			path = "CELT-0.7.0";
+			fileType = "compiled.mach-o.dylib";
+			path = "CELT-0.7.0.dylib";
 			remoteRef = 28492311132ED60700B4EAAC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -828,7 +838,7 @@
 		2849232C132ED61800B4EAAC /* ProtocolBuffers */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.dylib";
-			path = ProtocolBuffers;
+			path = ProtocolBuffers.dylib;
 			remoteRef = 2849232B132ED61800B4EAAC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -842,7 +852,7 @@
 		28492338132ED63800B4EAAC /* OpenSSL */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.dylib";
-			path = OpenSSL;
+			path = OpenSSL.dylib;
 			remoteRef = 28492337132ED63800B4EAAC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -856,7 +866,7 @@
 		28492347132ED64D00B4EAAC /* Speex */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.dylib";
-			path = Speex;
+			path = Speex.dylib;
 			remoteRef = 28492346132ED64D00B4EAAC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -870,7 +880,7 @@
 		28492353132ED65800B4EAAC /* SpeexDSP */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.dylib";
-			path = SpeexDSP;
+			path = SpeexDSP.dylib;
 			remoteRef = 28492352132ED65800B4EAAC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -884,7 +894,7 @@
 		285B426314E6E1200045E282 /* Opus */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.dylib";
-			path = Opus;
+			path = Opus.dylib;
 			remoteRef = 285B426214E6E1200045E282 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -962,6 +972,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0245A133154F593C00476144 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Opus (Mac)";
+			targetProxy = 0245A132154F593C00476144 /* PBXContainerItemProxy */;
+		};
 		283363CA13EE070400A04F04 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "CELT-0.7 (iOS)";
@@ -1023,12 +1038,16 @@
 		2845A729132D9B2F0034D631 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		2845A72A132D9B2F0034D631 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -1048,6 +1067,8 @@
 		28498F1C138AB6A9000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = BetaDist;
 		};
@@ -1067,6 +1088,8 @@
 		28A2AEC41478A92700F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				SDKROOT = macosx;
 			};
 			name = AppStore;
 		};

--- a/src/MKAudio.m
+++ b/src/MKAudio.m
@@ -291,6 +291,7 @@ static void MKAudio_SetupAudioSession(MKAudio *audio) {
 }
 
 - (BOOL) echoCancellationAvailable {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     NSDictionary *dict = nil;
     UInt32 valSize = sizeof(NSDictionary *);
     OSStatus err = AudioSessionGetProperty(kAudioSessionProperty_AudioRouteDescription, &valSize, &dict);
@@ -308,7 +309,7 @@ static void MKAudio_SetupAudioSession(MKAudio *audio) {
 
     if ([inputKind isEqualToString:(NSString *)kAudioSessionInputRoute_BuiltInMic])
         return YES;
-
+#endif
     return NO;
 }
 


### PR DESCRIPTION
fixes SDK & arch settings on mac targets, excludes an iOS block of code and adds Opus as dependency.

I set SDK & arch on each mac target as it seemed better than duplicating all the config files and having Debug-mac.xcconfig etc.  Everything is building successfully for me, but haven't had time to build a test app for it to really try using it.
