### PR TITLE
Set MKAudioDevice input to NULL before releasing it

### DIFF
--- a/src/MKAudioInput.m
+++ b/src/MKAudioInput.m
@@ -174,7 +174,7 @@
 }
 
 - (void) dealloc {
-    [_device setInput:NULL];
+    [_device setupInput:NULL];
     [_device release];
 
     [frameList release];


### PR DESCRIPTION
Hopefully it will solve a crash that may happen in AURemoteIO::IOThread. Anyway it shouldn't have any side-effect.
