### PR TITLE
Exposed Ping Time on MKConnection

### DIFF
--- a/src/MKConnection.m
+++ b/src/MKConnection.m
@@ -882,7 +882,10 @@ out:
 }
 
 - (void) _pingResponseFromServer:(MPPing *)pingMessage {
-    NSLog(@"MKConnection: pingResponseFromServer");
+    uint64_t timeStamp = pingMessage.timestamp;
+    uint64_t now = [self _currentTimeStamp] - _connTime;
+    _lastTcpPing = now - timeStamp;
+    NSLog(@"MKConnection: pingResponseFromServer = %llu usec", self.lastTcpPing);
 }
 
 // The server rejected our connection.

--- a/src/MumbleKit/MKConnection.h
+++ b/src/MumbleKit/MKConnection.h
@@ -316,6 +316,9 @@ typedef enum {
 /// server that the MKConnection object is currently connected to.
 - (NSString *) serverOSVersion;
 
+/// The last round-trip time from our internal TCP server ping
+@property (readonly) uint64_t lastTcpPing;
+
 ///-------------------------------------
 /// @name Authenticating with the server
 ///-------------------------------------


### PR DESCRIPTION
Our client needed this data to incorporate latency into a computation, and it
didn't appear to be exposed anywhere.
