### PR TITLE
Update MKUser.h

### DIFF
--- a/src/MumbleKit/MKUser.h
+++ b/src/MumbleKit/MKUser.h
@@ -1,6 +1,7 @@
 // Copyright 2009-2012 The MumbleKit Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+#import <Foundation/Foundation.h>
 
 typedef enum {
     MKTalkStatePassive = 0,


### PR DESCRIPTION
Fix error: Cannot find interface declaration for 'NSObject', superclass of 'MKUser'
