### PR TITLE
Do not set kAUVoiceIOProperty_VoiceProcessingQuality on audio unit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/speex"]
 	path = 3rdparty/speex
-	url = git://git.xiph.org/speex.git/
+	url = https://git.xiph.org/speex.git
 [submodule "3rdparty/celt-0.7.0"]
 	path = 3rdparty/celt-0.7.0
 	url = git://github.com/mumble-voip/celt-0.7.0.git
@@ -9,10 +9,10 @@
 	url = git://github.com/booyah/protobuf-objc.git
 [submodule "3rdparty/celt-0.8.0"]
 	path = 3rdparty/celt-0.8.0
-	url = git://git.xiph.org/celt.git
+	url = https://git.xiph.org/celt.git
 [submodule "3rdparty/openssl"]
 	path = 3rdparty/openssl
 	url = git://github.com/mkrautz/openssl-mirror.git
 [submodule "3rdparty/opus"]
 	path = 3rdparty/opus
-	url = git://git.xiph.org/opus.git
+	url = https://git.xiph.org/opus.git

--- a/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
+++ b/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
@@ -346,12 +346,14 @@
 		280D5F90132AE73C00540C3D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		280D5F91132AE73C00540C3D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -365,6 +367,7 @@
 		28498F26138AB6D5000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = BetaDist;
 		};
@@ -402,6 +405,7 @@
 		28A2AECF1478AA2400F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = AppStore;
 		};

--- a/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
+++ b/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
@@ -417,6 +417,28 @@
 			};
 			name = AppStore;
 		};
+		BCF56B281C9F2E8000CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28190CFB150D600400E07613 /* Base.xcconfig */;
+			buildSettings = {
+			};
+			name = Distribution;
+		};
+		BCF56B291C9F2E8000CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				SKIP_INSTALL = YES;
+			};
+			name = Distribution;
+		};
+		BCF56B2A1C9F2E8000CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				SDKROOT = macosx;
+			};
+			name = Distribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -425,6 +447,7 @@
 			buildConfigurations = (
 				280D5F8D132AE73C00540C3D /* Debug */,
 				280D5F8E132AE73C00540C3D /* Release */,
+				BCF56B281C9F2E8000CF88DA /* Distribution */,
 				28A2AECE1478AA2400F3B83F /* AppStore */,
 				28498F25138AB6D5000509DD /* BetaDist */,
 			);
@@ -436,6 +459,7 @@
 			buildConfigurations = (
 				280D5F90132AE73C00540C3D /* Debug */,
 				280D5F91132AE73C00540C3D /* Release */,
+				BCF56B291C9F2E8000CF88DA /* Distribution */,
 				28A2AECF1478AA2400F3B83F /* AppStore */,
 				28498F26138AB6D5000509DD /* BetaDist */,
 			);
@@ -447,6 +471,7 @@
 			buildConfigurations = (
 				2865611B132AE7A80011637C /* Debug */,
 				2865611C132AE7A80011637C /* Release */,
+				BCF56B2A1C9F2E8000CF88DA /* Distribution */,
 				28A2AED01478AA2400F3B83F /* AppStore */,
 				28498F27138AB6D5000509DD /* BetaDist */,
 			);

--- a/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
+++ b/3rdparty/celt-0.7.0-build/CELT-0.7.xcodeproj/project.pbxproj
@@ -252,7 +252,7 @@
 		280D5F7C132AE73C00540C3D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 280D5F7F132AE73C00540C3D /* Build configuration list for PBXProject "CELT-0.7" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
+++ b/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
@@ -3116,7 +3116,7 @@
 		28F58C3D132AF1070053C348 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 28F58C40132AF1070053C348 /* Build configuration list for PBXProject "OpenSSL" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
+++ b/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
@@ -4497,6 +4497,28 @@
 			};
 			name = Release;
 		};
+		BCF56B221C9F2E7200CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28190CEB150D5B6C00E07613 /* Base.xcconfig */;
+			buildSettings = {
+			};
+			name = Distribution;
+		};
+		BCF56B231C9F2E7200CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				SKIP_INSTALL = YES;
+			};
+			name = Distribution;
+		};
+		BCF56B241C9F2E7200CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				SDKROOT = macosx;
+			};
+			name = Distribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -4505,6 +4527,7 @@
 			buildConfigurations = (
 				28F58C4E132AF1070053C348 /* Debug */,
 				28F58C4F132AF1070053C348 /* Release */,
+				BCF56B221C9F2E7200CF88DA /* Distribution */,
 				28A2AEC61478AA0F00F3B83F /* AppStore */,
 				28498F1D138AB6C0000509DD /* BetaDist */,
 			);
@@ -4516,6 +4539,7 @@
 			buildConfigurations = (
 				28F58C51132AF1070053C348 /* Debug */,
 				28F58C52132AF1070053C348 /* Release */,
+				BCF56B231C9F2E7200CF88DA /* Distribution */,
 				28A2AEC71478AA0F00F3B83F /* AppStore */,
 				28498F1E138AB6C0000509DD /* BetaDist */,
 			);
@@ -4527,6 +4551,7 @@
 			buildConfigurations = (
 				28F58C62132AF1170053C348 /* Debug */,
 				28F58C63132AF1170053C348 /* Release */,
+				BCF56B241C9F2E7200CF88DA /* Distribution */,
 				28A2AEC81478AA0F00F3B83F /* AppStore */,
 				28498F1F138AB6C0000509DD /* BetaDist */,
 			);

--- a/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
+++ b/3rdparty/opensslbuild/OpenSSL.xcodeproj/project.pbxproj
@@ -4418,6 +4418,7 @@
 		28498F1E138AB6C0000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = BetaDist;
 		};
@@ -4439,6 +4440,7 @@
 		28A2AEC71478AA0F00F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = AppStore;
 		};
@@ -4468,12 +4470,14 @@
 		28F58C51132AF1070053C348 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		28F58C52132AF1070053C348 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
+++ b/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
@@ -1037,6 +1037,7 @@
 		285B423A14E6E0F00045E282 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = AppStore;
 		};
@@ -1058,6 +1059,7 @@
 		285B423E14E6E0F50045E282 /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = BetaDist;
 		};
@@ -1087,12 +1089,14 @@
 		287D85B414E6D474002B5D79 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		287D85B514E6D474002B5D79 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
+++ b/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
@@ -1100,6 +1100,28 @@
 			};
 			name = Release;
 		};
+		BCF56B2B1C9F2E8D00CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28190D02150D611E00E07613 /* Base.xcconfig */;
+			buildSettings = {
+			};
+			name = Distribution;
+		};
+		BCF56B2C1C9F2E8D00CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				SKIP_INSTALL = YES;
+			};
+			name = Distribution;
+		};
+		BCF56B2D1C9F2E8D00CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				SDKROOT = macosx;
+			};
+			name = Distribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1108,6 +1130,7 @@
 			buildConfigurations = (
 				2815CCD314E6DF9700AAE69C /* Debug */,
 				2815CCD414E6DF9700AAE69C /* Release */,
+				BCF56B2D1C9F2E8D00CF88DA /* Distribution */,
 				285B423B14E6E0F00045E282 /* AppStore */,
 				285B423F14E6E0F50045E282 /* BetaDist */,
 			);
@@ -1119,6 +1142,7 @@
 			buildConfigurations = (
 				287D85B114E6D474002B5D79 /* Debug */,
 				287D85B214E6D474002B5D79 /* Release */,
+				BCF56B2B1C9F2E8D00CF88DA /* Distribution */,
 				285B423914E6E0F00045E282 /* AppStore */,
 				285B423D14E6E0F50045E282 /* BetaDist */,
 			);
@@ -1130,6 +1154,7 @@
 			buildConfigurations = (
 				287D85B414E6D474002B5D79 /* Debug */,
 				287D85B514E6D474002B5D79 /* Release */,
+				BCF56B2C1C9F2E8D00CF88DA /* Distribution */,
 				285B423A14E6E0F00045E282 /* AppStore */,
 				285B423E14E6E0F50045E282 /* BetaDist */,
 			);

--- a/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
+++ b/3rdparty/opusbuild/Opus.xcodeproj/project.pbxproj
@@ -705,7 +705,7 @@
 		287D859D14E6D474002B5D79 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 287D85A014E6D474002B5D79 /* Build configuration list for PBXProject "Opus" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
+++ b/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
@@ -348,12 +348,14 @@
 		2845A6B2132D99550034D631 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		2845A6B3132D99550034D631 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -383,6 +385,7 @@
 		28498F22138AB6C9000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = BetaDist;
 		};
@@ -404,6 +407,7 @@
 		28A2AECB1478AA1B00F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = AppStore;
 		};

--- a/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
+++ b/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
@@ -250,7 +250,7 @@
 		2845A69E132D99550034D631 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 2845A6A1132D99550034D631 /* Build configuration list for PBXProject "ProtocolBuffers" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
+++ b/3rdparty/protobufbuild/ProtocolBuffers.xcodeproj/project.pbxproj
@@ -419,6 +419,28 @@
 			};
 			name = AppStore;
 		};
+		BCF56B251C9F2E7900CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28190CF2150D5D7300E07613 /* Base.xcconfig */;
+			buildSettings = {
+			};
+			name = Distribution;
+		};
+		BCF56B261C9F2E7900CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				SKIP_INSTALL = YES;
+			};
+			name = Distribution;
+		};
+		BCF56B271C9F2E7900CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				SDKROOT = macosx;
+			};
+			name = Distribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -427,6 +449,7 @@
 			buildConfigurations = (
 				2845A6AF132D99550034D631 /* Debug */,
 				2845A6B0132D99550034D631 /* Release */,
+				BCF56B251C9F2E7900CF88DA /* Distribution */,
 				28A2AECA1478AA1B00F3B83F /* AppStore */,
 				28498F21138AB6C9000509DD /* BetaDist */,
 			);
@@ -438,6 +461,7 @@
 			buildConfigurations = (
 				2845A6B2132D99550034D631 /* Debug */,
 				2845A6B3132D99550034D631 /* Release */,
+				BCF56B261C9F2E7900CF88DA /* Distribution */,
 				28A2AECB1478AA1B00F3B83F /* AppStore */,
 				28498F22138AB6C9000509DD /* BetaDist */,
 			);
@@ -449,6 +473,7 @@
 			buildConfigurations = (
 				2845A6C3132D99600034D631 /* Debug */,
 				2845A6C4132D99600034D631 /* Release */,
+				BCF56B271C9F2E7900CF88DA /* Distribution */,
 				28A2AECC1478AA1B00F3B83F /* AppStore */,
 				28498F23138AB6C9000509DD /* BetaDist */,
 			);

--- a/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
+++ b/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
@@ -507,6 +507,28 @@
 			};
 			name = Release;
 		};
+		BCF56B2E1C9F2E9700CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28190D05150D61EB00E07613 /* Base.xcconfig */;
+			buildSettings = {
+			};
+			name = Distribution;
+		};
+		BCF56B2F1C9F2E9700CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				SKIP_INSTALL = YES;
+			};
+			name = Distribution;
+		};
+		BCF56B301C9F2E9700CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				SDKROOT = macosx;
+			};
+			name = Distribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -515,6 +537,7 @@
 			buildConfigurations = (
 				28D1DAF0132AEB1500456ED6 /* Debug */,
 				28D1DAF1132AEB1500456ED6 /* Release */,
+				BCF56B2E1C9F2E9700CF88DA /* Distribution */,
 				28A2AED21478AA3200F3B83F /* AppStore */,
 				28498F29138AB6DB000509DD /* BetaDist */,
 			);
@@ -526,6 +549,7 @@
 			buildConfigurations = (
 				28D1DAF3132AEB1500456ED6 /* Debug */,
 				28D1DAF4132AEB1500456ED6 /* Release */,
+				BCF56B2F1C9F2E9700CF88DA /* Distribution */,
 				28A2AED31478AA3200F3B83F /* AppStore */,
 				28498F2A138AB6DB000509DD /* BetaDist */,
 			);
@@ -537,6 +561,7 @@
 			buildConfigurations = (
 				28D1DB04132AEB2200456ED6 /* Debug */,
 				28D1DB05132AEB2200456ED6 /* Release */,
+				BCF56B301C9F2E9700CF88DA /* Distribution */,
 				28A2AED41478AA3200F3B83F /* AppStore */,
 				28498F2B138AB6DB000509DD /* BetaDist */,
 			);

--- a/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
+++ b/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		28498F2A138AB6DB000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = BetaDist;
 		};
@@ -449,6 +450,7 @@
 		28A2AED31478AA3200F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = AppStore;
 		};
@@ -478,12 +480,14 @@
 		28D1DAF3132AEB1500456ED6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		28D1DAF4132AEB1500456ED6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
+++ b/3rdparty/speexbuild/Speex.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 		28D1DADF132AEB1400456ED6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 28D1DAE2132AEB1400456ED6 /* Build configuration list for PBXProject "Speex" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
+++ b/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 		28498F2E138AB6E2000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = BetaDist;
 		};
@@ -291,12 +292,14 @@
 		28877EC9132D96F300793CC5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		28877ECA132D96F300793CC5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -326,6 +329,7 @@
 		28A2AED71478AA3C00F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = AppStore;
 		};

--- a/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
+++ b/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
@@ -341,6 +341,28 @@
 			};
 			name = AppStore;
 		};
+		BCF56B311C9F2E9F00CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28190D0B150D624800E07613 /* Base.xcconfig */;
+			buildSettings = {
+			};
+			name = Distribution;
+		};
+		BCF56B321C9F2E9F00CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				SKIP_INSTALL = YES;
+			};
+			name = Distribution;
+		};
+		BCF56B331C9F2E9F00CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				SDKROOT = macosx;
+			};
+			name = Distribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -349,6 +371,7 @@
 			buildConfigurations = (
 				28877EC6132D96F300793CC5 /* Debug */,
 				28877EC7132D96F300793CC5 /* Release */,
+				BCF56B311C9F2E9F00CF88DA /* Distribution */,
 				28A2AED61478AA3C00F3B83F /* AppStore */,
 				28498F2D138AB6E2000509DD /* BetaDist */,
 			);
@@ -360,6 +383,7 @@
 			buildConfigurations = (
 				28877EC9132D96F300793CC5 /* Debug */,
 				28877ECA132D96F300793CC5 /* Release */,
+				BCF56B321C9F2E9F00CF88DA /* Distribution */,
 				28A2AED71478AA3C00F3B83F /* AppStore */,
 				28498F2E138AB6E2000509DD /* BetaDist */,
 			);
@@ -371,6 +395,7 @@
 			buildConfigurations = (
 				28877EDA132D975D00793CC5 /* Debug */,
 				28877EDB132D975D00793CC5 /* Release */,
+				BCF56B331C9F2E9F00CF88DA /* Distribution */,
 				28A2AED81478AA3C00F3B83F /* AppStore */,
 				28498F2F138AB6E2000509DD /* BetaDist */,
 			);

--- a/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
+++ b/3rdparty/speexdspbuild/SpeexDSP.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 		28877EB5132D96F300793CC5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 28877EB8132D96F300793CC5 /* Build configuration list for PBXProject "SpeexDSP" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/MumbleKit.xcodeproj/project.pbxproj
+++ b/MumbleKit.xcodeproj/project.pbxproj
@@ -1206,6 +1206,28 @@
 			};
 			name = Release;
 		};
+		BCF56B1F1C9F2E6600CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2815C4E1150D559800136082 /* Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Distribution;
+		};
+		BCF56B201C9F2E6600CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				SKIP_INSTALL = YES;
+			};
+			name = Distribution;
+		};
+		BCF56B211C9F2E6600CF88DA /* Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				SDKROOT = macosx;
+			};
+			name = Distribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1214,6 +1236,7 @@
 			buildConfigurations = (
 				2845A729132D9B2F0034D631 /* Debug */,
 				2845A72A132D9B2F0034D631 /* Release */,
+				BCF56B211C9F2E6600CF88DA /* Distribution */,
 				28A2AEC41478A92700F3B83F /* AppStore */,
 				28498F1C138AB6A9000509DD /* BetaDist */,
 			);
@@ -1225,6 +1248,7 @@
 			buildConfigurations = (
 				28BCF2C9132AE3B40003AEC1 /* Debug */,
 				28BCF2CA132AE3B40003AEC1 /* Release */,
+				BCF56B1F1C9F2E6600CF88DA /* Distribution */,
 				28A2AEC21478A92700F3B83F /* AppStore */,
 				28498F1A138AB6A9000509DD /* BetaDist */,
 			);
@@ -1236,6 +1260,7 @@
 			buildConfigurations = (
 				28BCF2CC132AE3B40003AEC1 /* Debug */,
 				28BCF2CD132AE3B40003AEC1 /* Release */,
+				BCF56B201C9F2E6600CF88DA /* Distribution */,
 				28A2AEC31478A92700F3B83F /* AppStore */,
 				28498F1B138AB6A9000509DD /* BetaDist */,
 			);

--- a/MumbleKit.xcodeproj/project.pbxproj
+++ b/MumbleKit.xcodeproj/project.pbxproj
@@ -837,7 +837,7 @@
 		28BCF2B8132AE3B40003AEC1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0620;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 28BCF2BB132AE3B40003AEC1 /* Build configuration list for PBXProject "MumbleKit" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/MumbleKit.xcodeproj/project.pbxproj
+++ b/MumbleKit.xcodeproj/project.pbxproj
@@ -837,7 +837,7 @@
 		28BCF2B8132AE3B40003AEC1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0620;
 			};
 			buildConfigurationList = 28BCF2BB132AE3B40003AEC1 /* Build configuration list for PBXProject "MumbleKit" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1143,6 +1143,7 @@
 		28498F1B138AB6A9000509DD /* BetaDist */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = BetaDist;
 		};
@@ -1164,6 +1165,7 @@
 		28A2AEC31478A92700F3B83F /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = AppStore;
 		};
@@ -1193,12 +1195,14 @@
 		28BCF2CC132AE3B40003AEC1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		28BCF2CD132AE3B40003AEC1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/src/MKAudio.m
+++ b/src/MKAudio.m
@@ -379,6 +379,13 @@ static void MKAudio_UpdateAudioSessionSettings(MKAudio *audio) {
 #endif
         [_audioDevice setupDevice];
         _audioInput = [[MKAudioInput alloc] initWithDevice:_audioDevice andSettings:&_audioSettings];
+
+        _audioInput.inputCallback = ^(short *frames, unsigned int nsamp) {
+            if ([[self delegate] respondsToSelector:@selector(audio:didRecordMicrophoneDataWithBuffer:amount:)]) {
+                [[self delegate] audio:self didRecordMicrophoneDataWithBuffer:frames amount:nsamp];
+            };
+        };
+        
         [_audioInput setMainConnectionForAudio:_connection];
         _audioOutput = [[MKAudioOutput alloc] initWithDevice:_audioDevice andSettings:&_audioSettings];
         if (_audioSettings.enableSideTone) {

--- a/src/MKAudioInput.h
+++ b/src/MKAudioInput.h
@@ -8,6 +8,8 @@
 
 @interface MKAudioInput : NSObject
 
+@property (copy) void (^inputCallback)(short *frames, unsigned int nsamp);
+
 - (id) initWithDevice:(MKAudioDevice *)device andSettings:(MKAudioSettings *)settings;
 - (void) dealloc;
 

--- a/src/MKAudioInput.m
+++ b/src/MKAudioInput.m
@@ -167,7 +167,12 @@
     [self initializeMixer];
  
     [_device setupInput:^BOOL(short *frames, unsigned int nsamp) {
+        if (self.inputCallback) {
+            self.inputCallback(frames, nsamp);
+        }
+        
         [self addMicrophoneDataWithBuffer:frames amount:nsamp];
+        
         return YES;
     }];
 

--- a/src/MKVoiceProcessingDevice.m
+++ b/src/MKVoiceProcessingDevice.m
@@ -231,29 +231,6 @@ static OSStatus outputCallback(void *udata, AudioUnitRenderActionFlags *flags, c
         NSLog(@"MKVoiceProcessingDevice: Unable to disable VPIO AGC.");
         return NO;
     }
-
-    // When running Mumble built with the iOS 6.1 SDK, built using Xcode 4.6.3 on iOS 7,
-    // we sometimes get zero samples from the VPIO Audio Unit.  When building with Xcode 5
-    // against the iOS 7 SDK, everything is OK, though.
-    //
-    // This is somehow related to setting VoiceProcessingQuality in the 'low' range. If we don't set
-    // it at all (and thus presumably stay in the 'high quality' range) iOS 7 doesn't complain. So do
-    // that as a workaround for now.
-#if __IPHONE_OS_VERSION_MAX_ALLOWED <= 60100
-    if (!DeviceIsRunningiOS7OrGreater()) {
-#else
-    {
-#endif
-        // It's sufficient to set the quality to 0 for our use case; we do our own preprocessing
-        // after this, and the job of the VPIO is only to do echo cancellation.
-        val = 0;
-        len = sizeof(UInt32);
-        err = AudioUnitSetProperty(_audioUnit, kAUVoiceIOProperty_VoiceProcessingQuality, kAudioUnitScope_Global, 0, &val, len);
-        if (err != noErr) {
-            NSLog(@"MKVoiceProcessingDevice: unable to set VPIO quality.");
-            return NO;
-        }
-    }
     
     val = 0;
     len = sizeof(UInt32);

--- a/src/MKiOSAudioDevice.m
+++ b/src/MKiOSAudioDevice.m
@@ -38,7 +38,7 @@ static OSStatus inputCallback(void *udata, AudioUnitRenderActionFlags *flags, co
         b->mData = calloc(1, b->mDataByteSize);
     }
     
-    if (dev->_buflist.mBuffers->mDataByteSize < (nframes/dev->_micSampleSize)) {
+    if (dev->_buflist.mBuffers->mDataByteSize < (dev->_micSampleSize * nframes)) {
         NSLog(@"MKiOSAudioDevice: Buffer too small. Allocating more space.");
         AudioBuffer *b = dev->_buflist.mBuffers;
         free(b->mData);
@@ -46,6 +46,12 @@ static OSStatus inputCallback(void *udata, AudioUnitRenderActionFlags *flags, co
         b->mData = calloc(1, b->mDataByteSize);
     }
     
+    /*
+     AudioUnitRender modifies the mDataByteSize members with the
+     actual read bytes count. We need to write it back otherwise
+     we'll reallocate the buffer even if not needed.
+     */
+    UInt32 dataByteSize = dev->_buflist.mBuffers->mDataByteSize;
     err = AudioUnitRender(dev->_audioUnit, flags, ts, busnum, nframes, &dev->_buflist);
     if (err != noErr) {
 #ifndef TARGET_IPHONE_SIMULATOR
@@ -53,6 +59,7 @@ static OSStatus inputCallback(void *udata, AudioUnitRenderActionFlags *flags, co
 #endif
         return err;
     }
+    dev->_buflist.mBuffers->mDataByteSize = dataByteSize;
     
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     short *buf = (short *) dev->_buflist.mBuffers->mData;

--- a/src/MumbleKit/MKAudio.h
+++ b/src/MumbleKit/MKAudio.h
@@ -119,6 +119,9 @@ typedef struct _MKAudioSettings {
 ///
 /// @param audio  The MKAudio singleton instance.
 - (BOOL) audioShouldBeRunning:(MKAudio *)audio;
+
+- (void) audio:(MKAudio *)audio didRecordMicrophoneDataWithBuffer:(short *)input amount:(NSUInteger)nsamp;
+
 @end
 
 /// @class MKAudio MKAudio.h MumbleKit/MKAudio.h


### PR DESCRIPTION
That code disable echo cancellation when building MumbleKit for iOS 7+ with the latest version of Xcode. As kAUVoiceIOProperty_VoiceProcessingQuality is marked as deprecated since iOS 6, I consider safe to remove that code (btw we're already using MumbleKit in production without that).

Moreover I set SKIP_INSTALL to YES to the iOS libraries to make Archive working in Xcode.
