### PR TITLE
Fixed memset not setting entire array 0

### DIFF
--- a/src/MKAudioOutput.m
+++ b/src/MKAudioOutput.m
@@ -209,7 +209,7 @@
             }
         }
     } else {
-        memset((short *)frames, 0, nsamp * _numChannels);
+        memset((short *)frames, 0, nsamp * _numChannels * sizeof(short));
     }
     [_outputLock unlock];
 


### PR DESCRIPTION
The third parameter of memset is the number of bytes to be set. In this case we should set the entire `frames` array to be zero.
