### PR TITLE
Fix memory leak in MKConnection allocating MKCryptState

### DIFF
--- a/src/MKConnection.m
+++ b/src/MKConnection.m
@@ -243,6 +243,8 @@ static void MKConnectionUDPCallback(CFSocketRef sock, CFSocketCallBackType type,
         [[MKAudio sharedAudio] setMainConnectionForAudio:nil];
 
     } while (_reconnect);
+    
+    [_crypt release];
 
     [NSThread exit];
 }


### PR DESCRIPTION
When an MKConnection object is destroyed/deallocated, the allocated MKCryptState from the main() thread does not get released. It only gets released and re-allocated in the do/while loop itself but it also needs to be released when the while() condition eventually falls out.